### PR TITLE
fix: use TIMEOUT_BEACON_SEC for block_reward and sync_committee reward

### DIFF
--- a/eth_validator_watcher/beacon.py
+++ b/eth_validator_watcher/beacon.py
@@ -322,7 +322,7 @@ class Beacon:
 
         response = self.__get_retry_not_found(
             f"{self.__url}/eth/v1/beacon/rewards/blocks/{slot}",
-            timeout=10,
+            timeout=TIMEOUT_BEACON_SEC,
         )
 
         response.raise_for_status()
@@ -342,7 +342,7 @@ class Beacon:
         try:
             response = self.__post_retry_not_found(
                 f"{self.__url}/eth/v1/beacon/rewards/sync_committee/{slot}",
-                timeout=10,
+                timeout=TIMEOUT_BEACON_SEC,
             )
 
             response.raise_for_status()

--- a/eth_validator_watcher/entrypoint.py
+++ b/eth_validator_watcher/entrypoint.py
@@ -383,8 +383,9 @@ def _handler(
             exited_validators.process(our_exited_u_idx2val, our_withdrawable_idx2val)
 
             if len(our_labels) > 0:
-                for labels in list(map(dict, set(tuple(sorted(d.items())) for d in our_labels.values()))):
-                    our_active_validators_per_validator_gauge.labels(**labels).set(0)
+                our_active_validators_per_validator_gauge.clear()
+                # for labels in list(map(dict, set(tuple(sorted(d.items())) for d in our_labels.values()))):
+                #     our_active_validators_per_validator_gauge.labels(**labels)
                 for status, validators in our_status2idx2val.items():
                     for validator in validators.values():
                         labels = our_labels[validator.pubkey]

--- a/eth_validator_watcher/entrypoint.py
+++ b/eth_validator_watcher/entrypoint.py
@@ -384,8 +384,6 @@ def _handler(
 
             if len(our_labels) > 0:
                 our_active_validators_per_validator_gauge.clear()
-                # for labels in list(map(dict, set(tuple(sorted(d.items())) for d in our_labels.values()))):
-                #     our_active_validators_per_validator_gauge.labels(**labels)
                 for status, validators in our_status2idx2val.items():
                     for validator in validators.values():
                         labels = our_labels[validator.pubkey]


### PR DESCRIPTION
Just a quick fix to use TIMEOUT_BEACON_SEC for requests timeout instead of an hardcoded value